### PR TITLE
optimize state snapshotting on leader nodes

### DIFF
--- a/lib/applications.js
+++ b/lib/applications.js
@@ -87,7 +87,19 @@ Applications.prototype.bootstrap_from_host = function(application, containers){
 }
 
 Applications.prototype.snapshot = function(fn){
-    this.core.persistence.snapshot_applications(this.serialize(), fn);
+    // get current node's attributes
+    var attributes = this.core.cluster.legiond.get_attributes();
+
+    // get list of other leader nodes
+    var leaders = _.filter(_.values(this.core.hosts.get_all()), function(peer){
+        return peer.praetor.leader_eligible;
+    });
+
+    // snapshot to disk only if current node is the cluster leader and no other eligible leaders exist in the cluster
+    if(attributes.praetor.leader && _.isEmpty(leaders))
+        this.core.persistence.snapshot_applications(this.serialize(), fn);
+    else
+        return fn();
 }
 
 Applications.prototype.get = function(application_name){


### PR DESCRIPTION
only snapshots to disk on leader eligible nodes who are not in control of the cluster or the cluster leader if no other eligible leader nodes exist. reduces disk writes on controlling leader