### PR TITLE
remove host tag if restoring from a 'per_host' constrained application

### DIFF
--- a/lib/applications.js
+++ b/lib/applications.js
@@ -116,6 +116,9 @@ Applications.prototype.add = function(config, fn){
                         return fn(err);
 
                     async.each(containers, function(container, fn){
+                        if(_.has(container.tags, "constraints") && _.has(container.tags.constraints, "per_host") && _.has(container.tags, "host"))
+                            delete container.tags.host;
+
                         if(container.random_host_port)
                             container.host_port = null;
 


### PR DESCRIPTION
Fixes issue during backup restoration which prevented containers from being placed due to host tag auto generated by the per_host constraint.