### PR TITLE
Include Ohai attributes as CS system tags during cluster init

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -1,8 +1,10 @@
 var fs = require("fs");
 var _ = require("lodash");
 var async = require("async");
+var flatten = require("flat");
 var Myriad = require("myriad-kv");
 var CodexD = require("codexd");
+var Ohai = require("ohai-data");
 var constants = require([__dirname, "constants"].join("/"));
 var crypto = require([__dirname, "crypto"].join("/"));
 
@@ -34,15 +36,48 @@ Cluster.prototype.initialize = function(fn){
             legiond: self.legiond
         });
 
+        // get existing attributes
         var attributes = self.legiond.get_attributes();
-        self.legiond.set_attributes({
-            tags: _.defaults({
-                host: attributes.id,
-                host_name: attributes.host_name
-            }, attributes.tags)
-        });
 
-        self.set_id(fn);
+        // see if ohai can inspect this host
+        Ohai.detect(function(err, data){
+
+            var system_attributes = {};
+
+            if(!err) {
+                var flat_data = flatten(data);
+                _.each([
+                    'os',
+                    'os_version',
+                    'platform',
+                    'platform_version',
+                    'platform_build',
+                    'platform_family',
+                    'virtualization.system',
+                    'virtualization.role'
+                ], function(key) {
+                    if (_.has(flat_data, key))
+                        system_attributes[key] = flat_data[key];
+                });
+            }
+
+            // merge host
+            var tags = _.defaults({
+                host: attributes.id,
+                host_name: attributes.host_name,
+            }, attributes.tags);
+
+            // and ohai attributes if present
+            if (!_.isEmpty(system_attributes))
+                tags.system = system_attributes;
+
+            // save updated node attributes
+            self.legiond.set_attributes({
+                tags: tags
+            });
+
+            self.set_id(fn);
+        });
 
         // join channels
         _.each(self.core.options.channels, function(channel){

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,16 @@
   "name": "containership.core",
   "version": "1.4.3",
   "dependencies": {
+    "ohai-data": {
+      "version": "0.1.0",
+      "from": "ohai-data@",
+      "resolved": "https://registry.npmjs.org/ohai-data/-/ohai-data-0.1.0.tgz"
+    },
+    "flat": {
+      "version": "1.6.0",
+      "from": "flat@",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-1.6.0.tgz"
+    },
     "async": {
       "version": "0.8.0",
       "from": "async@^0.8.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "async": "^0.8.0",
     "body-parser": "^1.4.3",
     "codexd": "^0.1.1",
+    "flat": "^1.6.0",
     "lodash": "^2.4.1",
     "myriad-kv": "^0.2.2",
+    "ohai-data": "^0.1.0",
     "request": "^2.51.0",
     "winston": "^0.7.3"
   },


### PR DESCRIPTION
This PR adds the following Ohai attributes as ContainerShip tags during the cluster initialize method:

```
os
os_version
platform
platform_version
platform_build
platform_family
virtualization.system
virtualization.role
```

When added to containership, they're prefixed with `system.<tag>` like so:

```
system.os
system.os_version
system.platform
system.platform_version
system.platform_build
system.platform_family
system.virtualization_system
system.virtualization_role
```

If specific Ohai attributes are not present on the system, they will be excluded.  If the Ohai executable is not found, it will still silently continue and add the normal host id and host name tags as usual.