### PR TITLE
handle exceptions when we are not in development

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -20,6 +20,8 @@ Logger.prototype.initialize = function() {
     }
 
     this.logger.add(transport, {
+        // handle exceptions when we are not in development
+        handleExceptions: 'development' !== process.env.NODE_ENV,
         level: this.core.options['log-level'],
         filename: this.core.options['log-location']
     });


### PR DESCRIPTION
In production, when the logging transport is a `File` transport, errors were not being written. When we are in development, they get displayed on console by default.

@normanjoyner 