### PR TITLE
Change default location of myriad-kv snapshot

### DIFF
--- a/options.js
+++ b/options.js
@@ -66,7 +66,7 @@ module.exports = {
     'snapshot-location': {
         help: 'Location to write snapshots',
         metavar: 'SNAPSHOT_LOCATION',
-        default: '/tmp/containership.snapshot'
+        default: '/opt/containership/containership.snapshot'
     },
 
     mode: {


### PR DESCRIPTION
Move snapshot file under /opt as /tmp is wiped on container restart and server reboot

@nicktate 